### PR TITLE
Always tag with route_paths

### DIFF
--- a/kong/plugins/datadog-tags/handler.lua
+++ b/kong/plugins/datadog-tags/handler.lua
@@ -139,6 +139,11 @@ local function log(premature, conf, message)
       request_tags,
       string_format("%s:%s", "route_paths", table.concat(message.route.paths, ","))
     )
+  else
+    request_tags = append(
+      request_tags,
+      string_format("%s:%s", "route_paths", "/")
+    )
   end
 
   for _, metric_config in pairs(conf.metrics) do


### PR DESCRIPTION
correct me if I'm wrong, but at the moment the only way to get the main route in metrics would be to exclude all the other route_paths?
I suspect this would make it easier to query
WDYT?